### PR TITLE
Fixed: chat logging error

### DIFF
--- a/botler.py
+++ b/botler.py
@@ -21,7 +21,8 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler(sys.stderr))
 log.setLevel(logging.DEBUG)
 
-chatlog = open("chatlog", "r+")
+chatlog = open("chat.log", "a")
+
 def command(name, **options):
     '''Decorator for command functions.
 

--- a/commands/agenda.py
+++ b/commands/agenda.py
@@ -1,5 +1,0 @@
-white_list=("themind","flay","stringy","sphinx")
-@command("agenda")
-def agenda(nick, channel, message):
-    if nick not in white_list:
-        say("%s: Sorry, you're not authorized to use this feature."%nick)

--- a/commands/agenda.py
+++ b/commands/agenda.py
@@ -1,0 +1,5 @@
+white_list=("themind","flay","stringy","sphinx")
+@command("agenda")
+def agenda(nick, channel, message):
+    if nick not in white_list:
+        say("%s: Sorry, you're not authorized to use this feature."%nick)


### PR DESCRIPTION
The chat logging feature was broken. "chatlog" was opened in r+ mode and botler would die immediately because that file was not found. Changed the chat log name to "chat.log" and it now gets opened in append mode.